### PR TITLE
Change context to index

### DIFF
--- a/pilot/commands/main.py
+++ b/pilot/commands/main.py
@@ -8,7 +8,7 @@ from pilot.version import __version__
 from pilot.commands.auth import auth_commands
 from pilot.commands.search import search_commands, delete
 from pilot.commands.transfer import transfer_commands, status_commands, analyze
-from pilot.commands.project import project, context
+from pilot.commands.project import project, index
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ cli.add_command(auth_commands.logout)
 cli.add_command(auth_commands.profile_command)
 
 cli.add_command(project.project_command)
-cli.add_command(context.context_command)
+cli.add_command(index.index_command)
 
 cli.add_command(search_commands.list_command)
 cli.add_command(search_commands.describe)

--- a/pilot/commands/project/index.py
+++ b/pilot/commands/project/index.py
@@ -74,7 +74,8 @@ def set_index(ctx, index_name):
     if len(pc.project.load_all()) == 1:
         projects = pc.project.load_all()
         pc.project.current = list(projects.keys())[0]
-    ctx.invoke(info, context=index_name)
+    log.debug(f'Context set! Fetching general info for user...')
+    ctx.invoke(info, index=index_name)
     ctx.invoke(project_command)
     try:
         pc.load_tokens(requested_scopes=pc.context.get_value('scopes'))

--- a/pilot/commands/project/index.py
+++ b/pilot/commands/project/index.py
@@ -1,22 +1,25 @@
 import logging
+import uuid
+import sys
 import click
 
 from fair_research_login import ScopesMismatch
 
 from pilot import commands, exc
+from pilot.commands.project.project import project_command
 from pilot.context import DEFAULT_PROJECTS_CACHE_TIMEOUT
 
 log = logging.getLogger(__name__)
 
 
-@click.group(name='context', help='Set or display context information',
-             invoke_without_command=True, hidden=True)
+@click.group(name='index', help='Set or display index information',
+             invoke_without_command=True)
 @click.pass_context
-def context_command(ctx):
+def index_command(ctx):
     pc = commands.get_pilot_client()
 
     if ctx.invoked_subcommand is None:
-        click.echo('Set project with "pilot project set <myproject>"')
+        click.echo('Set index with "pilot index set <index_uuid>|<index_name>"')
         contexts = pc.context.load_all()
         fmt = '{} {}'
         for context in contexts:
@@ -26,20 +29,25 @@ def context_command(ctx):
                 click.echo(fmt.format(' ', context))
 
 
-@context_command.command(help='Update stored list of projects.', name='set')
-@click.argument('index_name', required=False)
-# @click.option('-u', '--index-uuid', 'index_uuid', help='Use this index uuid')
+@index_command.command(help='Set Pilot to use a different search index', name='set')
+@click.argument('index_name')
 @click.pass_context
-def set_context(ctx, index_name):
+def set_index(ctx, index_name):
     pc = commands.get_pilot_client()
     if not pc.context.get_context(index_name):
+        log.debug(f'No local context "{index_name}", attempting lookup...')
         try:
-            click.secho('looking up {}...'.format(index_name))
+            # Ensure we're using the index UUID, lookup by name is no longer possible
+            uuid.UUID(index_name)
+            index_uuid = index_name
+
+            click.secho('looking up {}...'.format(index_uuid))
             sc = pc.get_search_client()
-            index_uuid = sc.get_index(index_name).data['id']
-            pc.context.add_context(index_name, {
+            index_info = sc.get_index(index_uuid)
+            display_name = index_info['display_name']
+            pc.context.add_context(display_name, {
                 'client_id': 'e4d82438-00df-4dbd-ab90-b6258933c335',
-                'app_name': '{} app'.format(index_name),
+                'app_name': '{} app'.format(display_name),
                 'manifest_index': index_uuid,
                 'manifest_subject': 'globus://project-manifest.json',
                 'scopes': pc.DEFAULT_SCOPES,
@@ -50,20 +58,28 @@ def set_context(ctx, index_name):
                 'projects_default_search_index': index_uuid,
                 'projects_default_resource_server': 'petrel_https_server',
             })
+            index_name = display_name
+        except ValueError:
+            click.secho(f'"{index_name}": must be a UUID when adding a new '
+                        f'un-tracked search index.', fg='red')
+            sys.exit(1)
         except Exception as e:
             log.exception(e)
             click.secho('Unable to find index {}'.format(index_name))
-            return
+            sys.exit(2)
     pc.context.set_context(index_name)
+    log.debug('Updating index...')
     pc.context.update()
+    # If there is only one project, automatically set pilot to that one
+    if len(pc.project.load_all()) == 1:
+        projects = pc.project.load_all()
+        pc.project.current = list(projects.keys())[0]
     ctx.invoke(info, context=index_name)
-    ctx.invoke(commands.project.project.project_command)
+    ctx.invoke(project_command)
     try:
         pc.load_tokens(requested_scopes=pc.context.get_value('scopes'))
-        click.secho('Current credentials are sufficient, no need to login '
-                    'again.', fg='green')
     except ScopesMismatch:
-        click.secho('Scopes do not match for this context, please login '
+        click.secho('Scopes do not match for this index, please login '
                     'again.', fg='red')
     log.debug(pc.context.get_value('projects_default_search_index'))
     if not pc.project.load_all():
@@ -81,17 +97,17 @@ def set_context(ctx, index_name):
                     'config under [projects]\n{}'.format(example))
 
 
-@context_command.command(help='Print Context Details')
-@click.argument('context', required=False)
-def info(context=None):
+@index_command.command(help='Print Info for index')
+@click.argument('index', required=False)
+def info(index=None):
     pc = commands.get_pilot_client()
-    context = context or pc.context.current
-    if context is None:
-        click.echo('Use "pilot context info <context>" to list info about a '
+    index = index or pc.context.current
+    if index is None:
+        click.echo('Use "pilot index info <context>" to list info about a '
                    'project.')
         return
     try:
-        info = pc.context.get_context(context)
+        info = pc.context.get_context(index)
     except exc.PilotInvalidProject as pip:
         click.secho(str(pip), fg='red')
         return
@@ -103,7 +119,7 @@ def info(context=None):
     click.echo()
 
 
-@context_command.command(help='Update a context')
+@index_command.command(help='Update a context')
 def push():
     pc = commands.get_pilot_client()
     pc.context.push()

--- a/pilot/commands/project/index.py
+++ b/pilot/commands/project/index.py
@@ -19,7 +19,8 @@ def index_command(ctx):
     pc = commands.get_pilot_client()
 
     if ctx.invoked_subcommand is None:
-        click.echo('Set index with "pilot index set <index_uuid>|<index_name>"')
+        click.echo('Set index with "pilot index set <index_uuid>|'
+                   '<index_name>"')
         contexts = pc.context.load_all()
         fmt = '{} {}'
         for context in contexts:
@@ -29,7 +30,8 @@ def index_command(ctx):
                 click.echo(fmt.format(' ', context))
 
 
-@index_command.command(help='Set Pilot to use a different search index', name='set')
+@index_command.command(help='Set Pilot to use a different search index',
+                       name='set')
 @click.argument('index_name')
 @click.pass_context
 def set_index(ctx, index_name):
@@ -37,7 +39,8 @@ def set_index(ctx, index_name):
     if not pc.context.get_context(index_name):
         log.debug(f'No local context "{index_name}", attempting lookup...')
         try:
-            # Ensure we're using the index UUID, lookup by name is no longer possible
+            # Ensure we're using the index UUID, lookup by name is no longer
+            # possible
             uuid.UUID(index_name)
             index_uuid = index_name
 
@@ -74,7 +77,7 @@ def set_index(ctx, index_name):
     if len(pc.project.load_all()) == 1:
         projects = pc.project.load_all()
         pc.project.current = list(projects.keys())[0]
-    log.debug(f'Context set! Fetching general info for user...')
+    log.debug('Context set! Fetching general info for user...')
     ctx.invoke(info, index=index_name)
     ctx.invoke(project_command)
     try:

--- a/pilot/context.py
+++ b/pilot/context.py
@@ -102,7 +102,6 @@ class Context(config.ConfigSection):
         result = sc.get_subject(index, sub, result_format_version='2017-09-01')
         manifest = result.data['content'][0]
         group = self.get_value('projects_group')
-        log.debug(f'Fetched manifest')
         if group and update_groups_cache is True:
             log.debug('Updating groups...')
             subgroups = self.fetch_subgroups(group=group)
@@ -114,6 +113,7 @@ class Context(config.ConfigSection):
                     'No groups returned, user may not have access to '
                     'subgroups for this group.')
         if dry_run is False:
+            log.debug(f'Writing fresh context to config.')
             cfg = self.config.load()
             index_name = sc.get_index(index).data['display_name']
             context = manifest.get('context')

--- a/pilot/context.py
+++ b/pilot/context.py
@@ -113,7 +113,7 @@ class Context(config.ConfigSection):
                     'No groups returned, user may not have access to '
                     'subgroups for this group.')
         if dry_run is False:
-            log.debug(f'Writing fresh context to config.')
+            log.debug('Writing fresh context to config.')
             cfg = self.config.load()
             index_name = sc.get_index(index).data['display_name']
             context = manifest.get('context')

--- a/pilot/context.py
+++ b/pilot/context.py
@@ -102,6 +102,7 @@ class Context(config.ConfigSection):
         result = sc.get_subject(index, sub, result_format_version='2017-09-01')
         manifest = result.data['content'][0]
         group = self.get_value('projects_group')
+        log.debug(f'Fetched manifest')
         if group and update_groups_cache is True:
             log.debug('Updating groups...')
             subgroups = self.fetch_subgroups(group=group)

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -28,6 +28,12 @@ ANALYSIS_BLIND_FILES = [(os.path.join(BLIND_BASE, ext), mt)
 
 DEFAULT_EXPIRE = int(time.time()) + 60 * 60 * 48
 
+MOCK_INDEX_RECORD = {
+    'context': {},
+    'projects': {},
+    'groups': {},
+}
+
 MOCK_CONTEXT = {'test-context': {
     'app_name': 'my app',
     'client_id': 'e6a8d7ab-9087-4f5f-99f1-974446a64a10',

--- a/tests/unit/test_command_index.py
+++ b/tests/unit/test_command_index.py
@@ -2,7 +2,7 @@ import copy
 import uuid
 from click.testing import CliRunner
 from tests.unit.mocks import MOCK_INDEX_RECORD, GlobusResponse
-from pilot.commands.project.index import set_index, info, push
+from pilot.commands.project.index import set_index, info
 
 
 def test_set_index_with_prev_fetched_index(monkeypatch, mock_cli, mock_config,
@@ -35,8 +35,8 @@ def test_set_index_with_non_uuid(mock_cli):
 
 
 def test_set_index_with_new_index(monkeypatch, mock_cli, mock_config,
-                                           mock_search_client,
-                                           mock_search_result):
+                                  mock_search_client,
+                                  mock_search_result):
     # Result when pilot context calls get_subject on the manifest record
     manifest = copy.deepcopy(mock_search_result)
     manifest['content'][0] = MOCK_INDEX_RECORD

--- a/tests/unit/test_command_index.py
+++ b/tests/unit/test_command_index.py
@@ -23,6 +23,8 @@ def test_set_index_with_prev_fetched_index(monkeypatch, mock_cli, mock_config,
     runner = CliRunner()
     result = runner.invoke(set_index, ['test-context'])
     assert result.exit_code == 0
+    assert mock_search_client.get_subject.called
+    assert mock_search_client.get_subject
 
 
 def test_set_index_with_non_uuid(mock_cli):

--- a/tests/unit/test_command_index.py
+++ b/tests/unit/test_command_index.py
@@ -1,0 +1,61 @@
+import copy
+import uuid
+from click.testing import CliRunner
+from tests.unit.mocks import MOCK_INDEX_RECORD, GlobusResponse
+from pilot.commands.project.index import set_index, info, push
+
+
+def test_set_index_with_prev_fetched_index(monkeypatch, mock_cli, mock_config,
+                                           mock_search_client,
+                                           mock_search_result):
+    # Result when pilot context calls get_subject on the manifest record
+    manifest = copy.deepcopy(mock_search_result)
+    manifest['content'][0] = MOCK_INDEX_RECORD
+    sub_resp = GlobusResponse()
+    sub_resp.data = mock_search_result
+    mock_search_client.get_subject.return_value = sub_resp
+
+    # Result when pilot fetches the general index_data
+    index_resp = GlobusResponse()
+    index_resp.data = {'display_name': 'foo'}
+    mock_search_client.get_index.return_value = index_resp
+
+    runner = CliRunner()
+    result = runner.invoke(set_index, ['test-context'])
+    assert result.exit_code == 0
+
+
+def test_set_index_with_non_uuid(mock_cli):
+    runner = CliRunner()
+    result = runner.invoke(set_index, ['foo'])
+    assert result.exit_code != 0
+    assert 'must be a UUID' in result.output
+
+
+def test_set_index_with_new_index(monkeypatch, mock_cli, mock_config,
+                                           mock_search_client,
+                                           mock_search_result):
+    # Result when pilot context calls get_subject on the manifest record
+    manifest = copy.deepcopy(mock_search_result)
+    manifest['content'][0] = MOCK_INDEX_RECORD
+    sub_resp = GlobusResponse()
+    sub_resp.data = mock_search_result
+    mock_search_client.get_subject.return_value = sub_resp
+
+    # Result when pilot fetches the general index_data
+    index_resp = GlobusResponse()
+    index_resp.data = {'display_name': 'foo'}
+    mock_search_client.get_index.return_value = index_resp
+
+    # make a fake index
+    fake_index = str(uuid.uuid4())
+
+    runner = CliRunner()
+    result = runner.invoke(set_index, [fake_index])
+    assert result.exit_code == 0
+
+
+def test_get_info(mock_cli):
+    runner = CliRunner()
+    result = runner.invoke(info, ['test-context'])
+    assert result.exit_code == 0


### PR DESCRIPTION
Previously, 'context' was a hidden command to switch indices for pilot. Since pilot is now public, this has been changed to 'index' for clarity and made public. 